### PR TITLE
Improve project template: add CI, fix deps, add examples

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,21 @@
+root = true
+
+[*]
+end_of_line = lf
+insert_final_newline = true
+charset = utf-8
+trim_trailing_whitespace = true
+
+[*.py]
+indent_style = space
+indent_size = 4
+
+[*.{yml,yaml,toml}]
+indent_style = space
+indent_size = 2
+
+[Makefile]
+indent_style = tab
+
+[*.md]
+trim_trailing_whitespace = false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,31 @@
+name: CI
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v4
+
+      - name: Set up Python
+        run: uv python install
+
+      - name: Install dependencies
+        run: uv sync
+
+      - name: Lint
+        run: uv run ruff check .
+
+      - name: Check formatting
+        run: uv run ruff format --check .
+
+      - name: Run tests
+        run: uv run pytest

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,4 @@
-PROJ_NAME=PROJ_NAME
-
-.PHONY: all dryrun test
+.PHONY: all dryrun test lint format
 
 all:
 	snakemake --cores all -r -p
@@ -13,3 +11,9 @@ dag.svg: workflow/Snakefile
 
 test:
 	uv run pytest
+
+lint:
+	uv run ruff check .
+
+format:
+	uv run ruff format .

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ See [Python environment setup](https://yyahn.com/wiki/Python/Environment%20setup
 
 ## Linting and formatting
 
-[ruff](https://docs.astral.sh/ruff/) is included as a dev dependency. VS Code settings (`.vscode/settings.json`) enable format on save.
+[ruff](https://docs.astral.sh/ruff/) is included as a dev dependency. Use `make lint` to check for issues and `make format` to auto-format.
 
 ### Pre-commit hooks
 
@@ -63,9 +63,9 @@ Use the following instructions to initialize.
 
 Commands:
 - `uv sync` — install dependencies
-- `uv run pytest` — run tests
-- `uv run ruff check .` — lint
-- `uv run ruff format .` — format
+- `make test` — run tests
+- `make lint` — lint
+- `make format` — format
 - `make all` — run Snakemake pipeline
 
 Conventions:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,10 +14,14 @@ build-backend = "hatchling.build"
 packages = ["src/project_name"]
 
 [dependency-groups]
-dev = ["ruff"]
+dev = ["ruff", "pytest", "pytest-cov", "pre-commit"]
 
 [tool.ruff]
 line-length = 88
 
 [tool.ruff.lint]
 select = ["E", "F", "I"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+addopts = "--cov=project_name --cov-report=term-missing -q"

--- a/src/project_name/example.py
+++ b/src/project_name/example.py
@@ -1,0 +1,6 @@
+"""Example module — replace with your own code."""
+
+
+def hello(name: str = "world") -> str:
+    """Return a greeting string."""
+    return f"Hello, {name}!"

--- a/tests/test_example.py
+++ b/tests/test_example.py
@@ -1,0 +1,11 @@
+"""Example tests — replace with your own tests."""
+
+from project_name.example import hello
+
+
+def test_hello_default() -> None:
+    assert hello() == "Hello, world!"
+
+
+def test_hello_name() -> None:
+    assert hello("Alice") == "Hello, Alice!"


### PR DESCRIPTION
- Add pytest, pytest-cov, pre-commit to dev dependencies
- Add pytest configuration in pyproject.toml
- Add lint/format targets to Makefile, remove unused PROJ_NAME
- Add example module and test to give users a working starting point
- Add GitHub Actions CI workflow (lint, format check, tests)
- Add .editorconfig for cross-editor consistency
- Fix README: remove incorrect .vscode reference, use make targets

https://claude.ai/code/session_012TNv3qDVee7nBFUViVtRvM